### PR TITLE
buildkit, buildah: use overlay storage driver

### DIFF
--- a/artifacts/cbi.yaml.sh
+++ b/artifacts/cbi.yaml.sh
@@ -170,7 +170,7 @@ spec:
       containers:
       - name: cbi-buildkit-buildkitd
         image: tonistiigi/buildkit
-        args: ["--oci-worker-snapshotter", "native", "--addr", "tcp://0.0.0.0:1234"]
+        args: ["--addr", "tcp://0.0.0.0:1234"]
         imagePullPolicy: Always
         ports:
         - containerPort: 1234

--- a/hack/dind/config
+++ b/hack/dind/config
@@ -1,4 +1,5 @@
-DIND_CLUSTER_SH_URL=https://raw.githubusercontent.com/Mirantis/kubeadm-dind-cluster/77a19b5997722814aa9dfb785a08a5d199226fc8/fixed/dind-cluster-v1.9.sh
+# https://github.com/Mirantis/kubeadm-dind-cluster/pull/112
+DIND_CLUSTER_SH_URL=https://raw.githubusercontent.com/AkihiroSuda/kubeadm-dind-cluster/8f39bda6edf29fc119f9997554b096b6d062e2c2/fixed/dind-cluster-v1.9.sh
 DIND_CLUSTER_SH=/tmp/dind-cluster-v1.9.sh
 
 # hardcoded in DIND_CLUSTER_SH

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -29,6 +29,7 @@ tag="test-$(date +%s)"
 # TODO: move to golang
 for ex in ex0; do
     for plugin in docker buildkit buildah; do
+        echo "travis_fold:start:${ex}-${plugin}"
         echo "========== Testing ${ex} using ${plugin} plugin =========="
         # create a BuildJob
         (cat artifacts/examples/${ex}.yaml; echo "  pluginSelector: plugin.name=${plugin}") | kubectl create -f -
@@ -43,5 +44,6 @@ for ex in ex0; do
         kubectl logs -f ${pod}
         # delete the BuildJob
         kubectl delete buildjob ${ex}
+        echo "travis_fold:end:${ex}-${plugin}"
     done
 done

--- a/hack/test/travis.sh
+++ b/hack/test/travis.sh
@@ -10,6 +10,18 @@ set -x
 cd $(dirname $0)/../..
 
 export PATH=~/.kubeadm-dind-cluster:$PATH
-./hack/dind/up.sh  > dind.log 2>&1 || (cat dind.log; false)
+
+echo travis_fold:start:dind-up
+
+# workaround on travis: kubernetes/kubernetes-anywhere#88
+sudo mkdir /vlkp
+sudo chmod 777 /vlkp
+sudo mount -o bind /vlkp /vlkp
+sudo mount --make-rshared /vlkp
+export DIND_VARLIBKUBELETPODS_BASE=/vlkp
+
+./hack/dind/up.sh
+echo travis_fold:end:dind-up
+
 DOCKER_HOST=localhost:62375 ./hack/test/e2e.sh cbi-registry:5000/cbi
 # no need to call ./hack/dind/down.sh on travis

--- a/pkg/plugin/base/backend/buildah/buildah.go
+++ b/pkg/plugin/base/backend/buildah/buildah.go
@@ -63,16 +63,14 @@ func (b *Buildah) CreatePodTemplateSpec(ctx context.Context, buildJob crd.BuildJ
 			{
 				Name:  "buildah-job",
 				Image: b.Image,
-				// FIXME: figure out why we can't use overlay2 on kubeadm-dind-cluster,
-				// even with the emptyDir volume for /var/lib/containers/storage.
-				Command: []string{"buildah", "--storage-driver", "vfs",
+				Command: []string{"buildah",
 					"bud", "-t", buildJob.Spec.Image,
 					buildJob.Spec.Context.GitRef.URL,
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name: "buildah-storage-volume",
-						// we need this volume for overlay2 storage driver.
+						// we need this volume for overlay storage driver.
 						MountPath: "/var/lib/containers/storage",
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Fix https://github.com/containerbuilding/cbi/issues/22

ref: https://github.com/Mirantis/kubeadm-dind-cluster/pull/112