### PR TITLE
new plugin: kaniko

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plugin | Support Dockerfile | Support `cloudbuild.yaml` | Support LLB
 [OpenShift Image Builder](https://github.com/openshift/imagebuilder) | Planned | |
 [Orca](https://github.com/cyphar/orca-build) | Planned | |
 [Google Cloud Container Builder](https://cloud.google.com/container-builder/) | Planned | Planned |
-[kaniko](https://github.com/GoogleCloudPlatform/kaniko) | Soon 🔜✅ | |
+[kaniko](https://github.com/GoogleCloudPlatform/kaniko) | Yes ✅ | |
 
 Plugin | Support Git context | Support ConfigMap Context | Support BuildKitSession Context
 --- | --- | --- | ---
@@ -36,7 +36,7 @@ Plugin | Support Git context | Support ConfigMap Context | Support BuildKitSessi
 [OpenShift Image Builder](https://github.com/openshift/imagebuilder) | Planned | Planned |
 [Orca](https://github.com/cyphar/orca-build) | Planned | Planned |
 [Google Cloud Container Builder](https://cloud.google.com/container-builder/) | Planned | Planned |
-[kaniko](https://github.com/GoogleCloudPlatform/kaniko) | Planned | Soon 🔜✅ |
+[kaniko](https://github.com/GoogleCloudPlatform/kaniko) | Planned | Yes ✅ |
 
 
 Please feel free to open PRs to add other plugins.

--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -32,5 +32,9 @@ FROM base AS cbi-buildkit
 COPY --from=compile /cbi-buildkit /cbi-buildkit
 ENTRYPOINT ["/cbi-buildkit"]
 
+FROM base AS cbi-kaniko
+COPY --from=compile /cbi-kaniko /cbi-kaniko
+ENTRYPOINT ["/cbi-kaniko"]
+
 FROM alpine
 CMD echo 'nothing defined here, specify the target via `docker build --target`.'; false

--- a/artifacts/cbi.yaml.sh
+++ b/artifacts/cbi.yaml.sh
@@ -203,6 +203,44 @@ spec:
   selector:
     app: cbi-buildkit-buildkitd
 ---
+## CBI plugin stuff (kaniko)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cbi-kaniko
+  labels:
+    app: cbi-kaniko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cbi-kaniko
+  template:
+    metadata:
+      labels:
+        app: cbi-kaniko
+    spec:
+      containers:
+      - name: cbi-kaniko
+        image: ${REGISTRY}/cbi-kaniko:${TAG}
+        args: ["-logtostderr", "-v=4", "-kaniko-image=gcr.io/kaniko-project/executor:latest"]
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 12111
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbi-kaniko
+  labels:
+    app: cbi-kaniko
+spec:
+  ports:
+  - port: 12111
+    protocol: TCP
+  selector:
+    app: cbi-kaniko
+---
 ## CBID stuff
 apiVersion: apps/v1
 kind: Deployment
@@ -224,7 +262,7 @@ spec:
       containers:
       - name: cbid
         image: ${REGISTRY}/cbid:${TAG}
-        args: ["-logtostderr", "-v=4", "-cbi-plugins=cbi-docker,cbi-buildah,cbi-buildkit"]
+        args: ["-logtostderr", "-v=4", "-cbi-plugins=cbi-docker,cbi-buildah,cbi-buildkit,cbi-kaniko"]
         imagePullPolicy: Always
 EOF
 echo "generated ${out}"

--- a/cmd/cbi-kaniko/main.go
+++ b/cmd/cbi-kaniko/main.go
@@ -1,0 +1,53 @@
+/*
+Copyright The CBI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/golang/glog"
+
+	"github.com/containerbuilding/cbi/pkg/plugin/base/backend"
+	"github.com/containerbuilding/cbi/pkg/plugin/base/backend/kaniko"
+	"github.com/containerbuilding/cbi/pkg/plugin/base/cmd"
+)
+
+func main() {
+	o := cmd.Opts{
+		// glog installs itself to flag.CommandLine via init()
+		// flag.CommandLine is associated with flag.ExitOnError
+		FlagSet: flag.CommandLine,
+		Args:    os.Args[1:],
+	}
+	var (
+		image string
+	)
+	o.FlagSet.StringVar(&image, "kaniko-image", "", "image used for running kaniko job")
+	o.CreateBackend = func() (backend.Backend, error) {
+		if image == "" {
+			glog.Fatal("no kaniko-image provided")
+		}
+		b := &kaniko.Kaniko{
+			Image: image,
+		}
+		return b, nil
+	}
+	if err := cmd.Main(o); err != nil {
+		glog.Fatal(err)
+	}
+}

--- a/hack/build/build-push-apply.sh
+++ b/hack/build/build-push-apply.sh
@@ -22,7 +22,7 @@ fi
 cd $(dirname $0)/../..
 
 # Build images
-for t in cbid cbi-docker cbi-docker-docker cbi-buildah cbi-buildah-buildah cbi-buildkit; do
+for t in cbid cbi-docker cbi-docker-docker cbi-buildah cbi-buildah-buildah cbi-buildkit cbi-kaniko; do
   docker build -t ${REGISTRY}/${t}:${TAG} --target ${t} -f artifacts/Dockerfile .
   docker push ${REGISTRY}/${t}:${TAG}
 done

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -62,7 +62,10 @@ e2e ex-git-nopush buildkit
 e2e ex-git-nopush buildah
 
 # ex-configmap-nopush: configmap context
+# NOTE: no test for kaniko, because it always requires pushing at the moment.
 for f in docker buildkit buildah; do
     e2e ex-configmap-nopush $f
     kubectl delete configmap ex-configmap-nopush-configmap
 done
+
+# TODO: add tests for pushing

--- a/pkg/plugin/base/backend/kaniko/kaniko.go
+++ b/pkg/plugin/base/backend/kaniko/kaniko.go
@@ -1,0 +1,90 @@
+/*
+Copyright The CBI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kaniko
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	crd "github.com/containerbuilding/cbi/pkg/apis/cbi/v1alpha1"
+	pluginapi "github.com/containerbuilding/cbi/pkg/plugin/api"
+	"github.com/containerbuilding/cbi/pkg/plugin/base/backend"
+	"github.com/containerbuilding/cbi/pkg/plugin/base/backend/util"
+)
+
+type Kaniko struct {
+	Image string
+}
+
+var _ backend.Backend = &Kaniko{}
+
+func (b *Kaniko) Info(ctx context.Context, req *pluginapi.InfoRequest) (*pluginapi.InfoResponse, error) {
+	res := &pluginapi.InfoResponse{
+		Labels: map[string]string{
+			pluginapi.LPluginName:         "kaniko",
+			pluginapi.LLanguageDockerfile: "",
+			pluginapi.LContextConfigMap:   "",
+		},
+	}
+	return res, nil
+}
+
+func (b *Kaniko) commonPodSpec(buildJob crd.BuildJob) corev1.PodSpec {
+	podSpec := corev1.PodSpec{
+		RestartPolicy: corev1.RestartPolicyNever,
+		Containers: []corev1.Container{
+			{
+				Name:  "kaniko-job",
+				Image: b.Image,
+			},
+		},
+	}
+	return podSpec
+}
+
+func (b *Kaniko) CreatePodTemplateSpec(ctx context.Context, buildJob crd.BuildJob) (*corev1.PodTemplateSpec, error) {
+	if buildJob.Spec.Language.Kind != crd.LanguageKindDockerfile {
+		return nil, fmt.Errorf("unsupported Spec.Language: %v", buildJob.Spec.Language)
+	}
+	podSpec := b.commonPodSpec(buildJob)
+	if buildJob.Spec.Registry.Push {
+		if len(buildJob.Spec.Registry.SecretRefs) != 1 {
+			return nil, fmt.Errorf("expected 1 Spec.Registry.SecretRefs, got %d", len(buildJob.Spec.Registry.SecretRefs))
+		}
+		util.InjectRegistrySecret(&podSpec, 0, "/root", buildJob.Spec.Registry.SecretRefs[0])
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, []string{
+			"--destination=" + buildJob.Spec.Registry.Target,
+		}...)
+	} else {
+		return nil, fmt.Errorf("unsupported Spec.Push: %v", false)
+	}
+	switch k := buildJob.Spec.Context.Kind; k {
+	case crd.ContextKindConfigMap:
+		volMountPath := util.InjectConfigMap(&podSpec, 0, buildJob.Spec.Context.ConfigMapRef)
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, []string{
+			"--dockerfile=" + volMountPath + "/Dockerfile",
+			"--context=" + volMountPath,
+		}...)
+	default:
+		return nil, fmt.Errorf("unsupported Spec.Context: %v", k)
+	}
+	return &corev1.PodTemplateSpec{
+		Spec: podSpec,
+	}, nil
+}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

ref: https://github.com/GoogleContainerTools/kaniko/issues/63
cc @priyawadhwa @dlorenc @r2d4


Tested with Amazon ECR.
Of course it should work with GCR as well, although `kubectl create secret docker-registry`-style secret is needed.

### Installation
```
$ ./hack/build/build-push-apply.sh registry.example.com/cbi test-$(date +%s)
```

### Example job
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: foo-configmap
data:
  Dockerfile: |-
    FROM busybox
    ADD hello /
    RUN cat /hello
  hello: "hello, kaniko world"

---

apiVersion: cbi.containerbuilding.github.io/v1alpha1
kind: BuildJob
metadata:
  name: foo
spec:
  registry:
    target: registry.example.com/foo:bar
    push: true
    secretRefs:
      - name: registry-secret
  language:
    kind: Dockerfile
  context:
    kind: ConfigMap
    configMapRef:
      name: foo-configmap
  pluginSelector: plugin.name=kaniko
```
